### PR TITLE
MAINT: patch UNU.RAN to fix all the potential memory leaks

### DIFF
--- a/find_memory_leaks.py
+++ b/find_memory_leaks.py
@@ -1,0 +1,130 @@
+"""Find potential memory leaks when UNU.RAN is used in SciPy."""
+
+import pathlib
+import re
+import io
+import argparse
+import logging
+from textwrap import dedent
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+def _find_leaks(logger: logging.Logger, windowsize: int) -> int:
+    assert windowsize > 1, "windowsize must be greater than 1."
+    # UNU.RAN source directory
+    base = pathlib.Path(__file__).parent / "unuran" / "src"
+    # all the submodules under the UNU.RAN directory
+    dirs = [
+        "distr",
+        "distributions",
+        "methods",
+        "parser",
+        "specfunct",
+        "tests",
+        "urng",
+        "utils",
+    ]
+    # report the number of potential leaks found.
+    n_leaks = 0
+
+    for dir in dirs:
+        dir = base / dir
+        for file in dir.glob("*.c"):
+            with open(file, "rb") as f:
+                content = f.read().decode("utf-8", "ignore").strip().split("\n")
+            # find the _unur_error of _unur_check macro uses
+            # and store the line number at which it is found.
+            indices = []
+            for i in range(len(content)):
+                if (
+                    re.match("(.*)(_unur_check|_unur_error)(.*)", content[i])
+                    is not None
+                ):
+                    indices.append(i)
+            # iterate through all the lines where there is a check for error
+            # and search `windowsize` lines under the check for `free` keyword.
+            # if it is found, that means there is a potential memory leak there.
+            for i in indices:
+                leak = 0
+                for j in range(windowsize):
+                    if i + j >= len(content):
+                        break
+                    if re.match("(.*)free(.*)", content[i + j]):
+                        leak = 1
+                        n_leaks += 1
+                        break
+                if leak:
+                    infostr = f" {str(file)}:{i+1}: "
+                    logger.info(
+                        bcolors.OKGREEN
+                        + bcolors.BOLD
+                        + infostr
+                        + dedent(content[i])
+                        + bcolors.ENDC
+                    )
+                    for j in range(windowsize):
+                        if i + j >= len(content):
+                            break
+                        if re.match("(.*)free(.*)", content[i + j]):
+                            logger.info(
+                                len(infostr) * " "
+                                + bcolors.FAIL
+                                + bcolors.BOLD
+                                + dedent(content[i + j])
+                                + bcolors.ENDC
+                            )
+                        else:
+                            logger.info(len(infostr) * " " + dedent(content[i + j]))
+                    logger.info("")
+
+    # return the number of memory leaks
+    return n_leaks
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument(
+        "-v", action="store_true", help="Enable verbose logging.", default=False
+    )
+    parser.add_argument(
+        "--window-size",
+        type=int,
+        help="Window size. Number of lines to search for `free` under a check.",
+        default=5,
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Pass this flag if you don't want colors in your output.",
+        default=False,
+    )
+    parser.add_argument(
+        "--output", type=str, help="Dump the output to a file.", default=None
+    )
+    args = parser.parse_args()
+    if args.output or args.no_color:
+
+        class bcolors:
+            OKGREEN = ""
+            FAIL = ""
+            BOLD = ""
+            ENDC = ""
+
+    logging.basicConfig(filename=args.output, filemode="w")
+    logger = logging.getLogger("memory-leaks")
+    if args.output or args.v:
+        logger.setLevel(logging.INFO)
+    print(
+        "Number of potential memory leaks found:", _find_leaks(logger, args.window_size)
+    )

--- a/unuran/src/distributions/c_burr.c
+++ b/unuran/src/distributions/c_burr.c
@@ -514,8 +514,9 @@ unur_distr_burr( const double *params, int n_params )
   case 11:  distr->id = UNUR_DISTR_BURR_XI;   break;
   case 12:  distr->id = UNUR_DISTR_BURR_XII;  break;
   default:
+    free( distr );
     _unur_error(distr_name,UNUR_ERR_DISTR_DOMAIN,"type < 1 || type > 12");
-    free( distr ); return NULL;
+    return NULL;
   }
 
   /* name of distribution */

--- a/unuran/src/methods/arou.c
+++ b/unuran/src/methods/arou.c
@@ -889,11 +889,16 @@ _unur_arou_init( struct unur_par *par )
 
   /* compute segments for given starting points */
   if ( _unur_arou_get_starting_segments(gen)!=UNUR_SUCCESS ) {
-    _unur_error(gen->genid,UNUR_ERR_GEN_CONDITION,"PDF not T-concave");
+    char genid[256];
+    strcpy(genid, gen->genid);
 #ifdef UNUR_ENABLE_LOGGING
-    if (gen->debug) _unur_arou_debug_init(par,gen);
+    unsigned gen_debug = gen->debug;
 #endif
     _unur_par_free(par); _unur_arou_free(gen);
+    _unur_error(genid,UNUR_ERR_GEN_CONDITION,"PDF not T-concave");
+#ifdef UNUR_ENABLE_LOGGING
+    if (gen_debug) _unur_arou_debug_init(par,gen);
+#endif
     return NULL;
   }
 
@@ -966,8 +971,10 @@ _unur_arou_init( struct unur_par *par )
 
   /* is there any envelope at all ? */
   if (GEN->Atotal <= 0. || !_unur_isfinite(GEN->Atotal)) {
-    _unur_error(gen->genid,UNUR_ERR_GEN_DATA,"bad construction points");
+    char genid[256];
+    strcpy(genid, gen->genid);
     _unur_arou_free(gen);
+    _unur_error(genid,UNUR_ERR_GEN_DATA,"bad construction points");
     return NULL;
   }
 

--- a/unuran/src/methods/ars.c
+++ b/unuran/src/methods/ars.c
@@ -866,8 +866,10 @@ _unur_ars_init( struct unur_par *par )
 
   /* is there any hat at all ? */
   if (GEN->Atotal <= 0. || !_unur_isfinite(GEN->Atotal)) {
-    _unur_error(gen->genid,UNUR_ERR_GEN_DATA,"bad construction points.");
+    char genid[256];
+    strcpy(genid, gen->genid);
     _unur_ars_free(gen);
+    _unur_error(genid,UNUR_ERR_GEN_DATA,"bad construction points.");
     return NULL;
   }
 
@@ -1853,8 +1855,8 @@ _unur_ars_starting_intervals( struct unur_gen *gen )
       }
 
       else {
+  free(iv_new);
 	_unur_error(gen->genid,UNUR_ERR_GEN_CONDITION,"PDF not T-concave!");
-	free(iv_new);
 	return UNUR_ERR_GEN_CONDITION;
       }
     }

--- a/unuran/src/methods/dau.c
+++ b/unuran/src/methods/dau.c
@@ -720,8 +720,8 @@ _unur_dau_make_urntable( struct unur_gen *gen )
   if (rich == begin + GEN->urn_size + 1 ) {
     /* this must not happen:
        no rich strips found for Robin Hood algorithm. */
-    _unur_error(gen->genid,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
     free (begin);
+    _unur_error(gen->genid,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
     return UNUR_ERR_SHOULD_NOT_HAPPEN;
   }
 

--- a/unuran/src/methods/hinv.c
+++ b/unuran/src/methods/hinv.c
@@ -1455,8 +1455,8 @@ _unur_hinv_interval_new( struct unur_gen *gen, double p, double u )
     iv->u = u;
     break;
   default:
-    _unur_error(gen->genid,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
     free(iv);
+    _unur_error(gen->genid,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
     return NULL;
   }
 

--- a/unuran/src/methods/mvstd.c
+++ b/unuran/src/methods/mvstd.c
@@ -263,8 +263,9 @@ _unur_mvstd_init( struct unur_par *par )
   /* run special init routine for generator */
   if ( DISTR.init(gen)!=UNUR_SUCCESS ) {
     /* init failed --> could not find a sampling routine */
+    _unur_mvstd_free(gen);
     _unur_error(GENTYPE,UNUR_ERR_GEN_DATA,"variant for special generator");
-    _unur_mvstd_free(gen); return NULL; 
+    return NULL; 
   }
 
   /* check parameters */

--- a/unuran/src/methods/norta.c
+++ b/unuran/src/methods/norta.c
@@ -320,8 +320,11 @@ _unur_norta_init( struct unur_par *par )
   if ( gen->distr->set & UNUR_DISTR_SET_DOMAINBOUNDED ) {
     if ( DISTR.domainrect == NULL ) {
       /* cannot handle non-rectangular domain */
-      _unur_error(gen->genid,UNUR_ERR_GEN_CONDITION,"cannot handle non-rectangular domain");
-      _unur_norta_free(gen); return NULL;
+      char genid[256];
+      strcpy(genid, gen->genid);
+      _unur_norta_free(gen);
+      _unur_error(genid,UNUR_ERR_GEN_CONDITION,"cannot handle non-rectangular domain");
+      return NULL;
     }
     else { /* rectangular domain */
       if (_unur_distr_cvec_marginals_are_equal(DISTR.marginals, GEN->dim)) {
@@ -393,8 +396,10 @@ _unur_norta_init( struct unur_par *par )
 
     /* verify initialization of marginal generators */
     if (GEN->marginalgen_list == NULL) {
-      _unur_error(gen->genid,UNUR_ERR_GENERIC,"init of marginal generators failed");
+      char genid[256];
+      strcpy(genid, gen->genid);
       _unur_norta_free(gen);
+      _unur_error(genid,UNUR_ERR_GENERIC,"init of marginal generators failed");
       return NULL;
     }
   }
@@ -639,8 +644,8 @@ _unur_norta_nortu_setup( struct unur_gen *gen )
   eigenvalues = _unur_xmalloc(dim * sizeof(double));
   eigenvectors = _unur_xmalloc(dim * dim * sizeof(double));
   if (_unur_matrix_eigensystem(dim, sigma_y, eigenvalues, eigenvectors) != UNUR_SUCCESS) {
-    _unur_error(GENTYPE,UNUR_ERR_GEN_DATA,"cannot compute eigenvalues for given sigma_y");
     free(sigma_y); free(eigenvalues); free(eigenvectors);
+    _unur_error(GENTYPE,UNUR_ERR_GEN_DATA,"cannot compute eigenvalues for given sigma_y");
     return UNUR_ERR_GEN_DATA;
   }
 
@@ -683,8 +688,8 @@ _unur_norta_nortu_setup( struct unur_gen *gen )
     _unur_distr_free(mn_distr);
   }
   if (mn_gen == NULL) {
-    _unur_error(GENTYPE,UNUR_ERR_GEN_DATA,"(corrected) sigma_y not positive definit");
     free(sigma_y);
+    _unur_error(GENTYPE,UNUR_ERR_GEN_DATA,"(corrected) sigma_y not positive definit");
     return UNUR_ERR_GEN_DATA;
   }
   MNORMAL = mn_gen;

--- a/unuran/src/methods/nrou.c
+++ b/unuran/src/methods/nrou.c
@@ -538,8 +538,11 @@ _unur_nrou_init( struct unur_par *par )
 
   /* compute bounding rectangle */
   if (_unur_nrou_rectangle(gen)!=UNUR_SUCCESS) {
-    _unur_error(gen->genid , UNUR_ERR_GEN_CONDITION, "Cannot compute bounding rectangle");  
-    _unur_nrou_free(gen); return NULL;
+    char genid[256];
+    strcpy(genid, gen->genid);
+    _unur_nrou_free(gen);
+    _unur_error(genid , UNUR_ERR_GEN_CONDITION, "Cannot compute bounding rectangle");  
+    return NULL;
   }
 
 #ifdef UNUR_ENABLE_LOGGING

--- a/unuran/src/parser/stringparser.c
+++ b/unuran/src/parser/stringparser.c
@@ -543,9 +543,9 @@ unur_str2gen (const char *string)
       str_urng = token;
     }
     else {
-      _unur_error_unknown(token,"category");
       _unur_slist_free( mlist );
       if (str) free(str);
+      _unur_error_unknown(token,"category");
       return NULL;
     }
   }
@@ -957,16 +957,16 @@ _unur_str_distr( char *str_distr )
       }
       else {
 	if (*key != 'd') {
-	  _unur_error(GENTYPE,UNUR_ERR_STR_SYNTAX,"key for distribution does not start with 'd'"); 
-	  _unur_distr_free(distr);  /* remark: added for ROOT to make coverity integrity manager happy */ 
+    _unur_distr_free(distr);  /* remark: added for ROOT to make coverity integrity manager happy */
+	  _unur_error(GENTYPE,UNUR_ERR_STR_SYNTAX,"key for distribution does not start with 'd'");  
 	  return NULL;
 	}
       }
 
       /* get new distribution object */
       if (distr != NULL) {
+  _unur_distr_free(distr);
 	_unur_error(GENTYPE,UNUR_ERR_SHOULD_NOT_HAPPEN,""); 
-	_unur_distr_free(distr);
       }
 
       distr = _unur_str_distr_new(value);
@@ -1196,8 +1196,8 @@ _unur_str_distr_set_ii (UNUR_DISTR *distr, const char *key, char *type_args, cha
   /* or one list with 2 entries is given */
   else if ( !strcmp(type_args, "L") ) {
     if ( _unur_parse_ilist( args[0], &iarray ) < 2 ) {
-      _unur_error_args(key);
       free (iarray);
+      _unur_error_args(key);
 #ifdef UNUR_ENABLE_LOGGING
       /* write info into LOG file */
       if (_unur_default_debugflag & UNUR_DEBUG_SETUP)
@@ -1342,8 +1342,8 @@ _unur_str_distr_set_dd (UNUR_DISTR *distr, const char *key, char *type_args, cha
   /* or one list with 2 entries is given */
   else if ( !strcmp(type_args, "L") ) {
     if ( _unur_parse_dlist( args[0], &darray ) < 2 ) {
-      _unur_error_args(key);
       free (darray);
+      _unur_error_args(key);
 #ifdef UNUR_ENABLE_LOGGING
       /* write info into LOG file */
       if (_unur_default_debugflag & UNUR_DEBUG_SETUP)
@@ -1767,8 +1767,8 @@ _unur_str_par_set_ii (UNUR_PAR *par, const char *key, char *type_args, char **ar
   /* or one list with 2 entries is given */
   else if ( !strcmp(type_args, "L") ) {
     if ( _unur_parse_ilist( args[0], &iarray ) < 2 ) {
-      _unur_error_args(key);
       free (iarray);
+      _unur_error_args(key);
 #ifdef UNUR_ENABLE_LOGGING
       /* write info into LOG file */
       if (_unur_default_debugflag & UNUR_DEBUG_SETUP)
@@ -1969,8 +1969,8 @@ _unur_str_par_set_dd (UNUR_PAR *par, const char *key, char *type_args, char **ar
   /* or one list with 2 entries is given */
   else if ( !strcmp(type_args, "L") ) {
     if ( _unur_parse_dlist( args[0], &darray ) < 2 ) {
-      _unur_error_args(key);
       free (darray);
+      _unur_error_args(key);
 #ifdef UNUR_ENABLE_LOGGING
       /* write info into LOG file */
       if (_unur_default_debugflag & UNUR_DEBUG_SETUP)
@@ -2826,8 +2826,10 @@ _unur_str_error_unknown( const char *file, int line, const char *key, const char
 {
   struct unur_string *reason = _unur_string_new();
   _unur_string_append( reason, "unknown %s: '%s'", type, key );
-  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_UNKNOWN,reason->text);
+  char reason_text[256];
+  strcpy(reason_text, reason->text);
   _unur_string_free( reason );
+  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_UNKNOWN,reason_text);
 } /* end of _unur_str_error_unknown() */
 
 /*---------------------------------------------------------------------------*/
@@ -2846,8 +2848,10 @@ _unur_str_error_invalid( const char *file, int line, const char *key, const char
 {
   struct unur_string *reason = _unur_string_new();
   _unur_string_append( reason, "invalid data for %s '%s'", type, key );
-  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_INVALID,reason->text);
+  char reason_text[256];
+  strcpy(reason_text, reason->text);
   _unur_string_free( reason );
+  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_INVALID,reason_text);
 } /* end of _unur_str_error_invalid() */
 
 /*---------------------------------------------------------------------------*/
@@ -2865,8 +2869,10 @@ _unur_str_error_args( const char *file, int line, const char *key )
 {
   struct unur_string *reason = _unur_string_new();
   _unur_string_append( reason, "invalid argument string for '%s'", key );
-  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_INVALID,reason->text);
+  char reason_text[256];
+  strcpy(reason_text, reason->text);
   _unur_string_free( reason );
+  _unur_error_x( GENTYPE, file, line, "error", UNUR_ERR_STR_INVALID,reason_text);
 } /* end of _unur_str_error_args() */
 
 /*---------------------------------------------------------------------------*/

--- a/unuran/src/tests/chi2test.c
+++ b/unuran/src/tests/chi2test.c
@@ -348,8 +348,8 @@ _unur_test_chi2_cont( struct unur_gen *gen,
 
   /* Fr - Fl <= 0. is a fatal error */
   if (Fdelta <= 0.) {
-    _unur_error(gen->genid,UNUR_ERR_GENERIC,"Fdelta <= 0.");
     free (observed);
+    _unur_error(gen->genid,UNUR_ERR_GENERIC,"Fdelta <= 0.");
     return -1.;
   }
 
@@ -604,8 +604,20 @@ _unur_test_chi2_vec ( struct unur_gen *gen,
     marginals[i] = DISTR.marginals[i];
     marginal_cdf[i] = unur_distr_cont_get_cdf(DISTR.marginals[i]);
     if (marginals[i]==NULL || marginal_cdf[i]==NULL) {
+      /* free memory */
+      if (X)    free(X);
+      if (U)    free(U);
+      if (bm)   free(bm);
+      if (Linv) free(Linv);
+      if (marginals)  free (marginals);
+      if (marginal_cdf)  free (marginal_cdf);
+      if (Fl)   free(Fl);
+      if (Fr)   free(Fr);
+      if (Fdelta)   free(Fdelta);
       _unur_error(gen->distr->name,UNUR_ERR_DISTR_REQUIRED,"CDF of continuous standardized marginal");
-      pval_min = -2.; goto free_memory;
+      pval_min = -2.;
+      /* return result of test */
+      return pval_min * dim;
     }
   }
 
@@ -622,8 +634,20 @@ _unur_test_chi2_vec ( struct unur_gen *gen,
       Fdelta[i] = Fr[i] - Fl[i];
       /* Fr - Fl <= 0. is a fatal error */
       if (Fdelta[i] <= 0.) {
+  /* free memory */
+  if (X)    free(X);
+  if (U)    free(U);
+  if (bm)   free(bm);
+  if (Linv) free(Linv);
+  if (marginals)  free (marginals);
+  if (marginal_cdf)  free (marginal_cdf);
+  if (Fl)   free(Fl);
+  if (Fr)   free(Fr);
+  if (Fdelta)   free(Fdelta);
 	_unur_error(gen->genid,UNUR_ERR_GENERIC,"Fdelta <= 0.");
-	pval_min = -1.; goto free_memory;
+	pval_min = -1.;
+  /* return result of test */
+  return pval_min * dim;
       }
     }
   }
@@ -645,8 +669,20 @@ _unur_test_chi2_vec ( struct unur_gen *gen,
   if (L != NULL) {
     Linv  = _unur_xmalloc( dim * dim * sizeof(double));
     if (_unur_matrix_invert_matrix (dim, L, Linv, &Linv_det) != UNUR_SUCCESS) {
+      /* free memory */
+      if (X)    free(X);
+      if (U)    free(U);
+      if (bm)   free(bm);
+      if (Linv) free(Linv);
+      if (marginals)  free (marginals);
+      if (marginal_cdf)  free (marginal_cdf);
+      if (Fl)   free(Fl);
+      if (Fr)   free(Fr);
+      if (Fdelta)   free(Fdelta);
       _unur_error(test_name,UNUR_ERR_DISTR_DATA,"cannot compute inverse of Cholesky factor");
-      pval_min = -2.; goto free_memory;
+      pval_min = -2.;
+      /* return result of test */
+      return pval_min * dim;
     }
   }
 
@@ -698,7 +734,6 @@ _unur_test_chi2_vec ( struct unur_gen *gen,
 
   /* ----------------------------------------------------------------------------*/
 
-free_memory:
   /* free memory */
   if (X)    free(X);
   if (U)    free(U);
@@ -949,6 +984,7 @@ _unur_test_chi2test( double *prob,
     pval = 1. - _unur_cont_CDF( chi2, distr_chisquare );
   }
   else {
+    _unur_distr_free(distr_chisquare);
     _unur_error(test_name,UNUR_ERR_GENERIC,"CDF for CHI^2 distribution required");
     pval = -2.;
   }

--- a/unuran/src/tests/correlation.c
+++ b/unuran/src/tests/correlation.c
@@ -227,8 +227,8 @@ unur_test_cvec_rankcorr( double *rc, struct unur_gen *gen, int samplesize, int v
     marginals[i] = DISTR.marginals[i];
     marginal_cdf[i] = unur_distr_cont_get_cdf(DISTR.marginals[i]);
     if (marginals[i]==NULL || marginal_cdf[i]==NULL) {
-      _unur_error(gen->distr->name,UNUR_ERR_DISTR_REQUIRED,"CDF of continuous marginal");
       free (marginals);  free (marginal_cdf);
+      _unur_error(gen->distr->name,UNUR_ERR_DISTR_REQUIRED,"CDF of continuous marginal");
       return UNUR_ERR_DISTR_REQUIRED; }
   }
 

--- a/unuran/src/tests/countpdf.c
+++ b/unuran/src/tests/countpdf.c
@@ -252,8 +252,8 @@ unur_test_count_pdf( struct unur_gen *gen, int samplesize, int verbosity, FILE *
     }
     break;
   default: /* unknown ! */
-    _unur_error(test_name,UNUR_ERR_GENERIC,"cannot run test for method!");
     _unur_free(genclone);
+    _unur_error(test_name,UNUR_ERR_GENERIC,"cannot run test for method!");
     return -1;
   }
 

--- a/unuran/src/tests/timing.c
+++ b/unuran/src/tests/timing.c
@@ -163,9 +163,9 @@ unur_test_timing( struct unur_par *par,
 	unur_sample_vec(gen,vec);
       break;
     default: /* unknown ! */
-      _unur_error(test_name,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
       free(time_gen);
       if (vec) free(vec);
+      _unur_error(test_name,UNUR_ERR_SHOULD_NOT_HAPPEN,"");
       return NULL;
     }
 

--- a/unuran/src/utils/stream.c
+++ b/unuran/src/utils/stream.c
@@ -282,8 +282,8 @@ _unur_read_data( const char *filename, int no_of_entries, double **ar )
   /* open the file with the data */
   fp = fopen(filename, "r");
   if (fp == NULL) {
-    _unur_error("read_data",UNUR_ERR_GENERIC,"cannot open file");
     free(data);
+    _unur_error("read_data",UNUR_ERR_GENERIC,"cannot open file");
     return 0; 
   }
 
@@ -314,9 +314,9 @@ _unur_read_data( const char *filename, int no_of_entries, double **ar )
 
       /* no success reading a double */
       if (chktoline == toline) {
-	_unur_error("read_data",UNUR_ERR_GEN_DATA,"data file not valid");
-	free(data);
+  free(data);
 	fclose(fp);
+	_unur_error("read_data",UNUR_ERR_GEN_DATA,"data file not valid");
 	return 0;    /* terminate routine */
       }  
 


### PR DESCRIPTION
@mckib2

scipy/scipy#14215

I have added a Python script to help find memory leaks in a window under UNU.RAN checks. Before applying these changes, it reported around 50 leaks. Now, it reports around 18 leaks with window size 6 but most of them are:

  * false positives
  * not used or will ever be used in SciPy

I have fixed all the leaks under modules `discr`, `distribution`, `methods`, `tests`, `parser`, and `utils`. We currently don't use much of this code but we should be able to safely use it in the future if we want to with there changes.

Run the Python script to get all the errors: `python3 find_memory_leaks.py -v --window-size 6`
To store the output in a file, do: `python3 find_memory_leaks.py --window-size 6 --output leaks.txt`